### PR TITLE
Fix SonarQube Code Smell: Use assertEqual Instead of assertTrue

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -87,7 +87,7 @@ class TestProductRoutes(TestCase):
         for _ in range(count):
             test_product = ProductFactory()
             response = self.client.post(BASE_URL, json=test_product.serialize())
-            self.assertTrue(
+            self.assertEqual(
                 response.status_code, status.HTTP_201_CREATED, "Could not create test product"
             )
             new_product = response.get_json()


### PR DESCRIPTION
This pull request addresses a minor code smell identified by SonarQube in the `tests/test_routes.py` file. The change involves replacing the `assertTrue` assertion with `assertEqual` for better clarity and accuracy in test results.